### PR TITLE
Some basic improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,37 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>fr.azelart.artnetstack</groupId>
-  <artifactId>stack</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
-  <name>ArtNetStack</name>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>fr.azelart.artnetstack</groupId>
+    <artifactId>stack</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>ArtNetStack</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.5</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <properties>
+        <project.build.sourceEncoding>iso8859-15</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <encoding>iso8859-15</encoding>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                    <showDeprecation>true</showDeprecation>
+                    <showWarnings>true</showWarnings>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/main/java/fr/azelart/artnetstack/utils/ByteUtilsArt.java
+++ b/src/main/java/fr/azelart/artnetstack/utils/ByteUtilsArt.java
@@ -18,7 +18,7 @@ package fr.azelart.artnetstack.utils;
 public final class ByteUtilsArt {
 	
 	public static int byte2toIn( byte[] b, int offset ) {
-		return b[offset+1]<<8 | b[offset];
+		return (b[offset+1]&0xff)<<8 | (b[offset] & 0xff);
 		//return b[3]<<24 | b[2]<<16 | b[1]<<8 | b[0];
 	}
 	

--- a/src/test/java/fr/azelart/artnetstack/utils/ByteUtilsArtTest.java
+++ b/src/test/java/fr/azelart/artnetstack/utils/ByteUtilsArtTest.java
@@ -1,0 +1,32 @@
+package fr.azelart.artnetstack.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+/**
+ * Created with IntelliJ IDEA.
+ * User: matthias
+ * Date: 06.08.12
+ * Time: 22:49
+ * To change this template use File | Settings | File Templates.
+ */
+public class ByteUtilsArtTest {
+    @Test
+    public void testByte2toIn() throws Exception {
+        byte[][] test_data = new byte[][]{
+                new byte[]{0x00, 0x00},
+                new byte[]{(byte) 0xff, 0x00},
+                new byte[]{0x00, (byte) 0xff},
+                new byte[]{(byte) 0xff, (byte) 0xff}};
+        int[] results = new int[]{
+                0x0000,
+                0x00ff,
+                0xff00,
+                0xffff};
+        for (int i = 0; i < test_data.length; i++) {
+            Assert.assertEquals(Arrays.toString(test_data[i]) + " should be converted to " + results[i], results[i], ByteUtilsArt.byte2toIn(test_data[i], 0));
+        }
+    }
+}


### PR DESCRIPTION
Hi,

I just stumbled across your project and wanted to correct a mistake with your code.

As Java only uses signed byte values you should really look out for byte-values larger than 127 as they are interpreted as negative values.

The real problem?
When a unsigned byte value like 128 is stored, it is interpreted as the signed value -127. If you now cast this byte value to an int value Java adds 3 0xff-bytes so it has a int of value -127.
Result:
(anything < 8) | (-127) == -127
Work-Arround: Remove the unnecessary 3 0xff-bytes, so you have (-127 & 0xff) = 128.

To make sure, that you don't miss such bugs, you should add tests to you project and run "mvn test" frequently.

Regards

TC. 
