### PR TITLE
error into order of bytes into protocol

### DIFF
--- a/src/main/java/fr/azelart/artnetstack/utils/ArtNetPacketEncoder.java
+++ b/src/main/java/fr/azelart/artnetstack/utils/ArtNetPacketEncoder.java
@@ -134,8 +134,8 @@ public final class ArtNetPacketEncoder {
 		byteArrayOutputStream.write(ByteUtilsArt.in16toByte(20480));
 
 		// Version
-		byteArrayOutputStream.write(new Integer(Constants.ART_NET_VERSION).byteValue());
 		byteArrayOutputStream.write(MagicNumbers.MAGIC_NUMBER_ZERO);
+		byteArrayOutputStream.write(new Integer(Constants.ART_NET_VERSION).byteValue());
 		
 		// Sequence
 		byteArrayOutputStream.write(ByteUtilsArt.in8toByte(artDmxCounter));


### PR DESCRIPTION
See screenshot, into code the constant refers to 14 and the analyse shows a 3584 (at left your packet, at right a packet sent by a "usual" art net controller)

![artnet](https://cloud.githubusercontent.com/assets/915876/6157041/d0300ca8-b23e-11e4-953f-5dafccd5c7bc.jpg)
